### PR TITLE
Concurrency fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 smog
+smog-O*
 *.o

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,21 @@ CXXFLAGS=-I. -lboost_program_options -lstdc++ -lpthread -Wall -Wextra -g
 smog: smog.o kernel.o linear_scan.o random_access.o random_write.o pointer_chase.o cold.o dirty_pages.o
 	$(CXX) -o smog smog.o kernel.o linear_scan.o random_access.o random_write.o pointer_chase.o cold.o dirty_pages.o $(CXXFLAGS)
 
+opt:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -O1"
+	mv smog smog-O1
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -O2"
+	mv smog smog-O2
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -O3"
+	mv smog smog-O3
+	$(MAKE) clean
+	$(MAKE)
+
 clean:
 	$(RM) *.o
+
+veryclean:
+	$(RM) *.o smog smog-O*

--- a/dirty_pages.cpp
+++ b/dirty_pages.cpp
@@ -4,12 +4,6 @@
 void Dirty_Pages::Execute_Kernel() {
         while (1) {
                 for(size_t i = 0; i < m_page_count * g_page_size; i += g_page_size) {
-                        // Here I am assuming the impact of skipping a few pages is not
-                        // going to be a big issue
-                        if (g_measuring) {
-                                mem_fence();
-                                continue;
-                        }
                         uint64_t tmp = m_buffer[i].index;
                         m_buffer[i].scratch = tmp + 1;
 

--- a/linear_scan.cpp
+++ b/linear_scan.cpp
@@ -10,13 +10,6 @@ void Linear_Scan::Execute_Kernel() {
         while (1) {
 		//for(uint64_t i = 0; i < elements / 10; i += 10) {
 		for(uint64_t i = 0; i < elements; i++) {
-                        // Here I am assuming the impact of skipping a few pages is not
-                        // going to be a big issue
-                        if (g_measuring) {
-                                mem_fence();
-                                continue;
-                        }
-
                         sum += *(((uint64_t *)m_buffer) + i);
 			/*sum += *(((uint64_t *)m_buffer) + i + 1);
 			sum += *(((uint64_t *)m_buffer) + i + 2);
@@ -29,7 +22,6 @@ void Linear_Scan::Execute_Kernel() {
 			sum += *(((uint64_t *)m_buffer) + i + 9);
                         g_thread_status[m_id].count += 10;*/
 			g_thread_status[m_id].count += 1;
-			mem_fence();
 
                         volatile uint64_t delay = 0;
                         for(size_t j = 0; j < g_smog_delay; j++) {

--- a/linear_scan.cpp
+++ b/linear_scan.cpp
@@ -2,10 +2,12 @@
 #include <stdint.h>
 
 void Linear_Scan::Execute_Kernel() {
-	uint64_t sum = 0;
+	// mark this volatile so that gcc is strict about load and stores
+	// (as if they had side effects) so usage is not optimized away below.
+	volatile uint64_t sum = 0;
+
         uint64_t bytes = m_elements * sizeof(m_elements);
         uint64_t elements = bytes / sizeof(uint64_t);
-
 
         while (1) {
 		//for(uint64_t i = 0; i < elements / 10; i += 10) {

--- a/pointer_chase.cpp
+++ b/pointer_chase.cpp
@@ -3,7 +3,9 @@
 #include <cstdlib>
 
 void Pointer_Chase::Execute_Kernel() {
-	struct element *tmp = &m_buffer[0];
+	// mark this volatile so that gcc is strict about load and stores
+	// (as if they had side effects) so usage is not optimized away below.
+	volatile struct element *tmp = &m_buffer[0];
 
 	while (1) {
 			//tmp = tmp->next;

--- a/pointer_chase.cpp
+++ b/pointer_chase.cpp
@@ -6,13 +6,6 @@ void Pointer_Chase::Execute_Kernel() {
 	struct element *tmp = &m_buffer[0];
 
 	while (1) {
-			// Here I am assuming the impact of skipping a few pages is not
-			// going to be a big issue
-			if (g_measuring) {
-				mem_fence();
-				continue;
-			}
-
 			//tmp = tmp->next;
 			//tmp = tmp->next;
 			//tmp = tmp->next;

--- a/random_access.cpp
+++ b/random_access.cpp
@@ -3,7 +3,9 @@
 #include <stdint.h>
 
 void Random_Access::Execute_Kernel() {
-        uint64_t sum = 0;
+        // mark this volatile so that gcc is strict about load and stores
+        // (as if they had side effects) so usage is not optimized away below.
+        volatile uint64_t sum = 0;
 
         while (1) {
                 for(uint64_t i = 0; i < m_elements; i++) {

--- a/random_access.cpp
+++ b/random_access.cpp
@@ -7,13 +7,6 @@ void Random_Access::Execute_Kernel() {
 
         while (1) {
                 for(uint64_t i = 0; i < m_elements; i++) {
-                        // Here I am assuming the impact of skipping a few pages is not
-                        // going to be a big issue
-                        if (g_measuring) {
-                                mem_fence();
-                                continue;
-                        }
-
                         sum += m_buffer[ m_buffer[i].randoms[0] ].index;
 			sum += m_buffer[ m_buffer[i].randoms[1] ].index;
 			sum += m_buffer[ m_buffer[i].randoms[2] ].index;

--- a/random_write.cpp
+++ b/random_write.cpp
@@ -5,13 +5,6 @@
 void Random_Write::Execute_Kernel() {
         while (1) {
                 for(uint64_t i = 0; i < m_elements; i++) {
-                        // Here I am assuming the impact of skipping a few pages is not
-                        // going to be a big issue
-                        if (g_measuring) {
-                                mem_fence();
-                                continue;
-                        }
-
                         m_buffer[ m_buffer[i].randoms[0] ].scratch = i;
 		        m_buffer[ m_buffer[i].randoms[1] ].scratch = i;
 	            	m_buffer[ m_buffer[i].randoms[2] ].scratch = i;

--- a/smog.cpp
+++ b/smog.cpp
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	if(vm.count("kernels")) {
-		int size = 0;
+		size_t size = 0;
 		kernel_groups = vm["kernels"].as<std::vector<std::string>>();
 		for(std::string ks : kernel_groups) {
 			size += ks.size();
@@ -216,14 +216,14 @@ int main(int argc, char* argv[]) {
 	std::vector<std::thread> t_obj(threads);
 	std::vector<Thread_Options> topts;
 
-	int kernel_group_size = kernel_groups.size();
+	size_t kernel_group_size = kernel_groups.size();
 	int tid = 0;
 	for(size_t i = 0; i < kernel_group_size; i++) {
 		size_t pages_begin = std::round(double(smog_pages) / kernel_group_size * i);
 		size_t pages_end = std::round(double(smog_pages) / kernel_group_size * (i + 1)) - 1;
 		size_t thread_pages = pages_end - pages_begin + 1;
 		void *thread_buffer = (void*)((uintptr_t)buffer + pages_begin * g_page_size);
-		for(int k = 0; k < kernel_groups[i].size(); k++) {
+		for(size_t k = 0; k < kernel_groups[i].size(); k++) {
 			g_thread_status[i].count = 0;
 			Smog_Kernel *kernel;
 			switch(kernel_groups[i][k]) {

--- a/smog.cpp
+++ b/smog.cpp
@@ -54,6 +54,7 @@ int main(int argc, char* argv[]) {
 	// determine system characteristics
 	system_pages = sysconf(_SC_PHYS_PAGES);
 	g_page_size = sysconf(_SC_PAGE_SIZE);
+	size_t cache_line_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
 	hardware_concurrency = std::thread::hardware_concurrency();
 
 	// per default, spawn one SMOG thread per core
@@ -65,7 +66,15 @@ int main(int argc, char* argv[]) {
 	// per default, keep self-adjusting
 	size_t default_timeout = 0; // s
 
-	std::cout << "System page size: " << g_page_size << " Bytes" << std::endl;
+	std::cout << "System page size:       " << g_page_size << " Bytes" << std::endl;
+	std::cout << "System cache line size: " << cache_line_size << " Bytes" << std::endl;
+
+	// assert for correct cache line size
+	if (cache_line_size != CACHE_LINE_SIZE) {
+		std::cerr << "error: built with incorrect cache line size: " << CACHE_LINE_SIZE << " Bytes. expected: " << cache_line_size << " Bytes" << std::endl;
+		return 2;
+	}
+
 	// parse CLI options
 	popts::options_description description("SMOG Usage");
 	description.add_options()

--- a/smog.h
+++ b/smog.h
@@ -14,7 +14,11 @@ extern size_t g_smog_timeout;
 extern bool g_measuring;
 extern pthread_barrier_t g_initalization_finished;
 
-#define mem_fence()  __asm__ __volatile__ ("lwsync" : : : "memory")
+#if defined(__ppc64__) || defined(__PPC64__)
+#  define mem_fence()  __asm__ __volatile__ ("lwsync" : : : "memory")
+#else
+#  define mem_fence()
+#endif
 
 struct __attribute__((packed)) thread_status_t {
         size_t count;

--- a/smog.h
+++ b/smog.h
@@ -20,10 +20,17 @@ extern pthread_barrier_t g_initalization_finished;
 #  define mem_fence()
 #endif
 
-struct __attribute__((packed)) thread_status_t {
-        size_t count;
-	char padding[CACHE_LINE_SIZE - sizeof(size_t)];
+struct thread_status_t {
+        union {
+                struct {
+                        size_t count;
+                };
+                char padding[CACHE_LINE_SIZE];
+        };
 };
+
+// assert for correct padding
+static_assert (sizeof(thread_status_t) == CACHE_LINE_SIZE, "thread_status_t padded incorrectly");
 
 extern struct thread_status_t *g_thread_status;
 

--- a/smog.h
+++ b/smog.h
@@ -11,7 +11,6 @@
 extern size_t g_page_size;
 extern size_t g_smog_delay;
 extern size_t g_smog_timeout;
-extern bool g_measuring;
 extern pthread_barrier_t g_initalization_finished;
 
 #if defined(__ppc64__) || defined(__PPC64__)
@@ -24,6 +23,7 @@ struct thread_status_t {
         union {
                 struct {
                         size_t count;
+                        size_t last_count;
                 };
                 char padding[CACHE_LINE_SIZE];
         };


### PR DESCRIPTION
this PR addresses issues #2 #3 and #4 as well as adding some smaller fixes and improvements. in detail:

to fix #2 commit 36a71780bfeba0f3389087096ba621aa802fd221 double buffers the iteration count of the kernels instead of resetting it to zero. this way, there are no concurrent writes to the iteration counters of the threads, avoiding a race condition. this also makes the memory fences and g_measuring global obsolete.

to fix #3 commit 856d2d7529b2a545448d3e6d9416792e127f5a5c updates the thread_status_t struct to include an anonymous union and an anonymous sub-struct so that the size arithmetic of the padding array becomes unnecessary. the commit also adds a static assert to check that the padding is indeed correct, and a runtime assert that the cache line size that is assumed at compile time matches the one observed at runtime.

to fix #4 commit 52a0e288cfccd2701468e63e9533f3a6d6ea1357 introduces the volatile keyword where needed, to force the compiler to assume that writes and reads to marked variables have side effects and thus can't be optimized out of the program. in our case, the side effect is the time that the operation takes. As a consequence, smog now works with compiler optimization levels up to -O3, and I have verified using gdb that the statements are indeed not optimized out.

other noteworthy changes are commit 44207e4c8626bc85a30c821f1eccf075cc21b4ab that introduces a compile time guard around the Power-specific definition of mem_fence, such that smog now compiles again on x86 and arm, and commit 96efcb8b445eb2154cedd1f5419eaef5627faa34 that adds the monitor interval that used to be hard coded as a command line parameter (-M) with a default value of 1000ms, hopefully making future usage of smog more convenient.

As an interesting side effect, the time-per-item (latency) that smog reports for the linear scan has now dropped to around 4.4ns for a delay of 0. We might get this even lower if we add extra functions for the zero delay case that don't include the delay loop at all. I might test that later.